### PR TITLE
replace sapply with vapply args in chrom-plots

### DIFF
--- a/R/chrom-plots.R
+++ b/R/chrom-plots.R
@@ -41,14 +41,15 @@ binRegion = function(start, end, binSize=NULL, binCount=NULL, indicator=NULL) {
 	binCountByChrom = round((end-start)/binSize)
 	binCountByChrom[binCountByChrom==0]=1
 	binSizeByChrom = (end-start)/(binCountByChrom)
-	breaks = round(unlist(sapply(binCountByChrom, function(x) seq(from=0, to=x))) * rep(binSizeByChrom, (binCountByChrom+1)))
+	breaks = round(unlist(vapply(binCountByChrom, function(x) seq(from=0, to=x), 
+	             integer(binCountByChrom+1)) * rep(binSizeByChrom, (binCountByChrom+1))))
 	endpoints = cumsum(binCountByChrom + 1) 
 	startpoints = c(1, endpoints[-length(endpoints)]+1)
 
 	dt = data.table(start=breaks[-endpoints]+1, 
 					end=breaks[-startpoints],
 					id=rep((1:length(start)), binCountByChrom),
-					binID=unlist(sapply(binCountByChrom, function(x) seq(from=1, to=x))),
+					binID=unlist(vapply(binCountByChrom, function(x) seq(from=1, to=x), integer(binCountByChrom))),
 					ubinID=1:length(breaks[-startpoints]),
 					key="id")
 


### PR DESCRIPTION
- All the `sapply` in the Chrom distribution plot script were changed to `vapply`.
- There's one `sapply` left in the partitions plot script, but it's within a non-exported function. I am not sure how to change it since I don't know what the `tableCount` function does or where it comes from.