### PR TITLE
v1.3.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GenomicDistributions
-Version: 1.3.3
-Date: 2022-01-27
+Version: 1.3.4
+Date: 2022-02-16
 Title: GenomicDistributions: fast analysis of genomic intervals with Bioconductor
 Description: If you have a set of genomic ranges, this package can help you with
  visualization and comparison. It produces several kinds of plots, for example:

--- a/R/buildReferenceData.R
+++ b/R/buildReferenceData.R
@@ -40,6 +40,8 @@ retrieveFile = function(source, destDir=NULL){
 #'        the downloaded GTF file should be stored
 #' @param convertEnsemblUCSC a logical indicating whether Ensembl style 
 #'        chromosome annotation should be changed to UCSC style
+#' @param filterProteinCoding a logical indicating if TSSs should be only
+#'        protein-coding genes (default = TRUE)
 #'
 #' @return a list of GRanges objects
 #'
@@ -51,10 +53,17 @@ retrieveFile = function(source, destDir=NULL){
 #'                                  "C_elegans_cropped_example.gtf.gz", 
 #'                                  package="GenomicDistributions")
 #' CElegansTss = getTssFromGTF(CElegansGtfCropped, TRUE)
-getTssFromGTF = function(source, convertEnsemblUCSC=FALSE, destDir=NULL){
+getTssFromGTF = function(source, convertEnsemblUCSC=FALSE, destDir=NULL,
+                         filterProteinCoding=TRUE){
     GtfDf = as.data.frame(rtracklayer::import(retrieveFile(source, destDir)))
-    subsetGtfDf = GtfDf %>% 
-    dplyr::filter(gene_biotype == "protein_coding", type == "gene")
+    
+    if (filterProteinCoding) {
+      subsetGtfDf = GtfDf %>% 
+        dplyr::filter(gene_biotype == "protein_coding", type == "gene")
+    } else {
+      subsetGtfDf = GtfDf
+    }
+    
     gr = makeGRangesFromDataFrame(subsetGtfDf, keep.extra.columns = TRUE)
     feats = promoters(gr, 1, 1) 
     if(convertEnsemblUCSC)

--- a/man/getTssFromGTF.Rd
+++ b/man/getTssFromGTF.Rd
@@ -4,7 +4,12 @@
 \alias{getTssFromGTF}
 \title{Get transcription start sites (TSSs) from a remote or local GTF file}
 \usage{
-getTssFromGTF(source, convertEnsemblUCSC = FALSE, destDir = NULL)
+getTssFromGTF(
+  source,
+  convertEnsemblUCSC = FALSE,
+  destDir = NULL,
+  filterProteinCoding = TRUE
+)
 }
 \arguments{
 \item{source}{a string that is either a path to a local or remote GTF}
@@ -14,6 +19,9 @@ chromosome annotation should be changed to UCSC style}
 
 \item{destDir}{a string that indicates the path to the directory where 
 the downloaded GTF file should be stored}
+
+\item{filterProteinCoding}{a logical indicating if TSSs should be only
+protein-coding genes (default = TRUE)}
 }
 \value{
 a list of GRanges objects


### PR DESCRIPTION
non-model organisms don't often have "gene_biotype" column and therefore cannot filter protein-coding genes -> protein-coding filter is no just an option