### PR TITLE
v1.5.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GenomicDistributions
-Version: 1.5.1
-Date: 2022-06-14
+Version: 1.5.2
+Date: 2022-06-20
 Title: GenomicDistributions: fast analysis of genomic intervals with Bioconductor
 Description: If you have a set of genomic ranges, this package can help you with
  visualization and comparison. It produces several kinds of plots, for example:
@@ -59,7 +59,7 @@ VignetteBuilder: knitr
 License: BSD_2_clause + file LICENSE
 biocViews: Software, GenomeAnnotation, GenomeAssembly, DataRepresentation, Sequencing,
             Coverage, FunctionalGenomics, Visualization
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 URL: http://code.databio.org/GenomicDistributions
 BugReports: http://github.com/databio/GenomicDistributions
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GenomicDistributions
 Version: 1.5.2
-Date: 2022-06-20
+Date: 2022-06-30
 Title: GenomicDistributions: fast analysis of genomic intervals with Bioconductor
 Description: If you have a set of genomic ranges, this package can help you with
  visualization and comparison. It produces several kinds of plots, for example:
@@ -48,7 +48,8 @@ Suggests:
     testthat,
     knitr,
     BiocStyle,
-    rmarkdown
+    rmarkdown,
+    GenomicDistributionsData
 Enhances:
     BSgenome,
     extrafont,

--- a/R/buildReferenceData.R
+++ b/R/buildReferenceData.R
@@ -112,13 +112,11 @@ getGeneModelsFromGTF = function(source,
   retList = list()
   message("Extracting features: ", paste(features, collapse = ", "))
   for (feat in features) {
-    featGR = unique(GenomeInfoDb::keepStandardChromosomes(reduce(
+    featGR = unique(GenomeInfoDb::keepStandardChromosomes(
       GenomicRanges::makeGRangesFromDataFrame(
         subsetGtfDf %>% filter(type == feat),
         keep.extra.columns = TRUE
-      )
-    ),
-    pruning.mode = "coarse"))
+      ), pruning.mode = "coarse"))
     # change from Ensembl style chromosome annotation to UCSC style
     if (convertEnsemblUCSC)
       seqlevels(featGR) =  paste0("chr", seqlevels(featGR))

--- a/R/chrom-plots.R
+++ b/R/chrom-plots.R
@@ -242,8 +242,6 @@ calcChromBinsRef = function(query, refAssembly, binCount=3000) {
 #' 
 #' Plots result from \code{genomicDistribution} calculation
 #' @param genomeAggregate The output from the genomicDistribution function
-#' @param binCount Number of bins (should match the call to
-#'     \code{genomicDistribution})
 #' @param plotTitle Title for plot.
 #' @param ylim Limit of y-axes. Default "max" sets limit to N of biggest bin.
 #' @return A ggplot object showing the distribution of the query 
@@ -255,7 +253,7 @@ calcChromBinsRef = function(query, refAssembly, binCount=3000) {
 #'                 "withinGroupID"=1:5, "N"=c(1,3,5,7,9))  
 #' ChromBins = plotChromBins(agg)
 #' 
-plotChromBins = function(genomeAggregate, binCount=10000, 
+plotChromBins = function(genomeAggregate,
                            plotTitle="Distribution over chromosomes", ylim="max") {
     .validateInputs(list(genomeAggregate=c("data.table","data.frame")))
     
@@ -288,7 +286,7 @@ plotChromBins = function(genomeAggregate, binCount=10000,
             scale_y_continuous(breaks = ylim,
                                limits = c(0, ylim))
         }} +
-    scale_x_continuous(breaks=c(0, binCount), labels=c("Start", "End")) +
+    scale_x_continuous(breaks=c(0, max(genomeAggregate$withinGroupID)), labels=c("Start", "End")) +
     theme(plot.title=element_text(hjust=0.5)) + # Center title
     ggtitle(plotTitle) +
     theme(legend.position="bottom")

--- a/R/chrom-plots.R
+++ b/R/chrom-plots.R
@@ -211,7 +211,7 @@ calcChromBinsRef = function(query, refAssembly, binCount=3000) {
                            query=c("GRanges","GRangesList")))
     if (is(query, "GRangesList"))  {
         # Recurse over each GRanges object
-        x = lapply(query, calcChromBinsRef, refAssembly)
+        x = lapply(query, calcChromBinsRef, refAssembly, binCount)
         # To accommodate multiple regions, we'll need to introduce a new 'name'
         # column to distinguish them.
         nameList = names(query)

--- a/R/feature-plots.R
+++ b/R/feature-plots.R
@@ -195,8 +195,8 @@ plotFeatureDist = function(dists, bgdists=NULL, featureName="features",
                          by = name]$"Freq.Per"
             df$name = sortingFunction(df, labelOrder, nbins)
             # It has multiple regions
-            g = ggplot(df, aes(x=cuts, y=Freq, fill=name)) + 
-           facet_grid(. ~name)
+            g = ggplot(df, aes(x=cuts, y=Freq, fill=name, color = name)) + 
+            facet_grid(. ~name)
     } else {
         if (!numbers) 
             df$Freq = (df$Freq / sum(df$Freq)) * 100
@@ -239,10 +239,15 @@ plotFeatureDist = function(dists, bgdists=NULL, featureName="features",
         scale_x_continuous(breaks=c(1, ncuts), labels=c(minlabel, maxlabel))
         return(g)
     }
-
-    g = g +
-        geom_bar(data=df, stat="identity", fill="darkblue", alpha=0.7) + 
-        geom_point(aes(x=midx, y=0), color="tan2", size=2, 
+    
+    if ("name" %in% names(df)) {
+      g = g +
+        geom_bar(data=df, stat="identity", alpha=0.7) 
+    } else {
+      g = g +
+        geom_bar(data=df, stat="identity", fill="darkblue", alpha=0.7) 
+    }
+    g = g + geom_point(aes(x=midx, y=0), color="tan2", size=2, 
                    shape=17, alpha=0.8) +
         guides(fill="none") + # remove legend for geom_point
         theme_classic() + 

--- a/R/loadData.R
+++ b/R/loadData.R
@@ -73,7 +73,46 @@ loadEnsDb = function(genomeBuild) {
 #' @examples
 #' getChromSizes("hg19")
 getChromSizes = function(refAssembly) {
-    getReferenceData(refAssembly, tagline="chromSizes_")
+  datasetId = paste0("chromSizes_", refAssembly)
+  
+  if (refAssembly == "hg19"){
+    
+    chromSizesDataset = getReferenceData(refAssembly, tagline="chromSizes_")
+    
+  } else if (refAssembly == "hg38"){
+    
+    if (!"GenomicDistributionsData" %in% utils::installed.packages()){
+      stop(paste(datasetId, "not available in GenomicDistributions package",
+                 "and GenomicDistributionsData package is not installed"))
+    } else {
+      chromSizesDataset = GenomicDistributionsData::chromSizes_hg38()
+    }
+    
+  } else if (refAssembly == "mm10"){
+    
+    if (!"GenomicDistributionsData" %in% utils::installed.packages()){
+      stop(paste(datasetId, "not available in GenomicDistributions package",
+                 "and GenomicDistributionsData package is not installed"))
+    } else {
+      chromSizesDataset = GenomicDistributionsData::chromSizes_mm10()
+    }
+    
+  } else if (refAssembly == "mm9"){
+    
+    if (!"GenomicDistributionsData" %in% utils::installed.packages()){
+      stop(paste(datasetId, "not available in GenomicDistributions package",
+                 "and GenomicDistributionsData package is not installed"))
+    } else {
+      chromSizesDataset = GenomicDistributionsData::chromSizes_mm9()
+    }
+    
+  } else {
+    stop(paste(datasetId, "not available in GenomicDistributions package",
+               "or GenomicDistributionsData package,",
+               "please use getChromSizesFromFasta() to get chromosome sizes."))
+  }
+  
+  return(chromSizesDataset)
 }
 
 
@@ -81,7 +120,46 @@ getChromSizes = function(refAssembly) {
 #
 # @param refAssembly A string identifier for the reference assembly
 getTSSs = function(refAssembly) { 
-    getReferenceData(refAssembly, tagline="TSS_")
+  datasetId = paste0("TSS_", refAssembly)
+  
+  if (refAssembly == "hg19"){
+    
+    TSSs = getReferenceData(refAssembly, tagline="TSS_")
+    
+  } else if (refAssembly == "hg38"){
+    
+    if (!"GenomicDistributionsData" %in% utils::installed.packages()){
+      stop(paste(datasetId, "not available in GenomicDistributions package",
+                 "and GenomicDistributionsData package is not installed"))
+    } else {
+      TSSs = GenomicDistributionsData::TSS_hg38()
+    }
+    
+  } else if (refAssembly == "mm10"){
+    
+    if (!"GenomicDistributionsData" %in% utils::installed.packages()){
+      stop(paste(datasetId, "not available in GenomicDistributions package",
+                 "and GenomicDistributionsData package is not installed"))
+    } else {
+      TSSs = GenomicDistributionsData::TSS_mm10()
+    }
+    
+  } else if (refAssembly == "mm9"){
+    
+    if(!"GenomicDistributionsData" %in% utils::installed.packages()){
+      stop(paste(datasetId, "not available in GenomicDistributions package",
+                 "and GenomicDistributionsData package is not installed"))
+    } else {
+      TSSs = GenomicDistributionsData::TSS_mm9()
+    }
+    
+  } else {
+    stop(paste(datasetId, "not available in GenomicDistributions package",
+               "or GenomicDistributionsData package,",
+               "please use getTssFromGTF() to get list of TSSs."))
+  }
+  
+  return(TSSs)
 }
 
 
@@ -96,7 +174,47 @@ getTSSs = function(refAssembly) {
 #' @examples
 #' getGeneModels("hg19")
 getGeneModels = function(refAssembly) { 
-    getReferenceData(refAssembly, tagline="geneModels_")
+  datasetId = paste0("geneModels_", refAssembly)
+  
+  if(refAssembly == "hg19"){
+    
+    geneModelsDataset = getReferenceData(refAssembly, tagline="geneModels_")
+    
+  } else if(refAssembly == "hg38"){
+    
+    if(!"GenomicDistributionsData" %in% utils::installed.packages()){
+      stop(paste(datasetId, "not available in GenomicDistributions package",
+                 "and GenomicDistributionsData package is not installed"))
+    } else {
+      geneModelsDataset = GenomicDistributionsData::geneModels_hg38()
+    }
+    
+  } else if(refAssembly == "mm10"){
+    
+    if(!"GenomicDistributionsData" %in% utils::installed.packages()){
+      stop(paste(datasetId, "not available in GenomicDistributions package",
+                 "and GenomicDistributionsData package is not installed"))
+    } else {
+      geneModelsDataset = GenomicDistributionsData::geneModels_mm10()
+    }
+    
+  } else if(refAssembly == "mm9"){
+    
+    if(!"GenomicDistributionsData" %in% utils::installed.packages()){
+      stop(paste(datasetId, "not available in GenomicDistributions package",
+                 "and GenomicDistributionsData package is not installed"))
+    } else {
+      geneModelsDataset = GenomicDistributionsData::geneModels_mm9()
+    }
+    
+  } else {
+    stop(paste(datasetId, "not available in GenomicDistributions package",
+               "or GenomicDistributionsData package,",
+               "please use getGeneModelsFromGTF() to get",
+               "gene models."))
+  }
+  
+  return(geneModelsDataset)
 }
 
 #' Get reference data for a specified assembly

--- a/R/partition-plots.R
+++ b/R/partition-plots.R
@@ -135,15 +135,38 @@ genomePartitionList = function(genesGR, exonsGR, threeUTRGR=NULL,
     # subtract overlaps (promoterCore lies within PromoterProx)
     promoterProx = GenomicRanges::setdiff(promProx, promCore)
 
-    # remove any possible overlaps between classes
-    fiveUTRGR = GenomicRanges::setdiff(fiveUTRGR, threeUTRGR)
-    exonsGR = GenomicRanges::setdiff(exonsGR, threeUTRGR)
-    exonsGR = GenomicRanges::setdiff(exonsGR, fiveUTRGR)
-
-    #   introns = gene - (5'UTR, 3'UTR, exons)
-    nonThree = GenomicRanges::setdiff(genesGR, threeUTRGR)
-    nonThreeFive = GenomicRanges::setdiff(nonThree, fiveUTRGR)
-    intronGR = GenomicRanges::setdiff(nonThreeFive, exonsGR)
+    if(!is.null(threeUTRGR) & !is.null(fiveUTRGR)){
+      # we have both 3' and 5' elements
+      fiveUTRGR = GenomicRanges::setdiff(fiveUTRGR, threeUTRGR)
+      exonsGR = GenomicRanges::setdiff(exonsGR, threeUTRGR)
+      exonsGR = GenomicRanges::setdiff(exonsGR, fiveUTRGR)
+      
+      #   introns = gene - (5'UTR, 3'UTR, exons)
+      nonThree = GenomicRanges::setdiff(genesGR, threeUTRGR)
+      nonThreeFive = GenomicRanges::setdiff(nonThree, fiveUTRGR)
+      intronGR = GenomicRanges::setdiff(nonThreeFive, exonsGR)
+      
+    } else if (is.null(threeUTRGR) & !is.null(fiveUTRGR)){
+      # we have only 5' elements
+      exonsGR = GenomicRanges::setdiff(exonsGR, fiveUTRGR)
+      
+      #   introns = gene - (5'UTR, exons)
+      nonFive = GenomicRanges::setdiff(genesGR, fiveUTRGR)
+      intronGR = GenomicRanges::setdiff(nonFive, exonsGR)
+      
+    } else if (!is.null(threeUTRGR) & is.null(fiveUTRGR)){
+      # we have only 3' elements
+      exonsGR = GenomicRanges::setdiff(exonsGR, threeUTRGR)
+      
+      #   introns = gene - (3'UTR, exons)
+      nonThree = GenomicRanges::setdiff(genesGR, threeUTRGR)
+      intronGR = GenomicRanges::setdiff(nonThree, exonsGR)
+    } else {
+      # we don't have either 3' or 5' elements
+      
+      #   introns = gene - exons
+      intronGR = GenomicRanges::setdiff(genesGR, exonsGR)
+    }
 
     partitionList = list(promoterCore=promCore,
                          promoterProx=promoterProx,

--- a/man/plotChromBins.Rd
+++ b/man/plotChromBins.Rd
@@ -6,16 +6,12 @@
 \usage{
 plotChromBins(
   genomeAggregate,
-  binCount = 10000,
   plotTitle = "Distribution over chromosomes",
   ylim = "max"
 )
 }
 \arguments{
 \item{genomeAggregate}{The output from the genomicDistribution function}
-
-\item{binCount}{Number of bins (should match the call to
-\code{genomicDistribution})}
 
 \item{plotTitle}{Title for plot.}
 


### PR DESCRIPTION
bug fixes in:
- getGeneModelsFromGTF - removed reduce function - was throwing error
- calcSignalSummary - indexing with seq(1,3) was giving error -> replaced by c(1,2,3)
- genomePartitionList - was not working when 5'UTR and 3'UTR were NULL
- ref functions requiring GenomicDistributionsData package were not working - calling data with data() function does not work anymore in GenomicDistributionsData
- plotFeatureDist - when GRList is provided as query for calc function, each dataset will be plotted with different color